### PR TITLE
Add Slack Badge to enable faster communication with developers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Slack badge in documentation
 - Refactored route table creation to support updates of routes. The change requires manually updates. See [README.md](README.md)
 - Add output variables for route table ids
 - Added availability zone to output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We'd love for you to contribute to our source code and to make the Forest even b
 
 If you have questions about how to use the Forest, please direct these to the [Slack group / philips-software][slack].
 
-[![Slack](https://slackin-vdwxebygpt.now.sh/badge.svg)](https://slackin-vdwxebygpt.now.sh)
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 ## <a name="issue"></a> Found an Issue?
 
@@ -131,7 +131,7 @@ For more info, please reach out to the team on [Slack group / philips-software][
 
 Use the badge to sign-up.
 
-[![Slack](https://slackin-vdwxebygpt.now.sh/badge.svg)](https://slackin-vdwxebygpt.now.sh)
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 [contribute]: CONTRIBUTING.md
 [github]: https://github.com/philips-software/terraform-aws-vpc/issues 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,6 @@ We'd love for you to contribute to our source code and to make the Forest even b
  - [Issues and Bugs](#issue)
  - [Feature Requests](#feature)
  - [Submission Guidelines](#submit)
- - [Coding Rules](#rules)
- - [Commit Message Guidelines](#commit)
  - [Further Info](#info)
 
 ## <a name="question"></a> Got a Question or Problem?
@@ -126,6 +124,14 @@ from the main (upstream) repository:
     ```shell
     git pull --ff upstream master
     ```
+
+## <a name="info"></a> Info
+
+For more info, please reach out to the team on [Slack group / philips-software][slack] in the #forest channel.
+
+Use the badge to sign-up.
+
+[![Slack](https://slackin-vdwxebygpt.now.sh/badge.svg)](https://slackin-vdwxebygpt.now.sh)
 
 [contribute]: CONTRIBUTING.md
 [github]: https://github.com/philips-software/terraform-aws-vpc/issues 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT) Copyright © [2018] Koninklijke Philips N.V, https://www.philips.com
+The MIT License (MIT) Copyright © 2018 Koninklijke Philips N.V, https://www.philips.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,17 @@ module "y" {
 | public_subnets | List of the public subnets. |
 | vpc_cidr | VPC CDIR. |
 | vpc_id | ID of the VPC. |
+
+## Philips Forest
+
+This module is part of the Philips Forest.
+
+```
+                                                     ___                   _
+                                                    / __\__  _ __ ___  ___| |_
+                                                   / _\/ _ \| '__/ _ \/ __| __|
+                                                  / / | (_) | | |  __/\__ \ |_
+                                                  \/   \___/|_|  \___||___/\__|  
+
+                                                                 Infrastructure
+```

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ This module is part of the Philips Forest.
 
 Talk to the forestkeepers in the `forest`-channel on Slack.
 
-[![Slack](https://slackin-vdwxebygpt.now.sh/badge.svg)](https://slackin-vdwxebygpt.now.sh)
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)

--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ This module is part of the Philips Forest.
 
                                                                  Infrastructure
 ```
+
+Talk to the forestkeepers in the `forest`-channel on Slack.
+
+[![Slack](https://slackin-vdwxebygpt.now.sh/badge.svg)](https://slackin-vdwxebygpt.now.sh)


### PR DESCRIPTION
In README and CONTRIBUTING a link to the Philips-software OSS slack team is added.

People can sign up for the free Slack team by clicking the badge.