### PR TITLE
Add VPC Endpoint for S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add S3 VPC endpoint by default so the access to S3 is free from within the VPC
 
 ## [1.2.1] - 20-12-2018
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ module "y" {
 | cidr_block |  | string | `10.0.0.0/16` | no |
 | create_private_hosted_zone |  | string | `true` | no |
 | create_private_subnets |  | string | `true` | no |
+| create_s3_vpc_endpoint | Whether to create a VPC Endpoint for S3, so the S3 buckets can be used from within the VPC without using the NAT gateway. | string | `true` | no |
 | environment |  | string | - | yes |
 | project |  | string | `` | no |
 | public_subnet_map_public_ip_on_launch |  | string | `false` | no |

--- a/examples/vpc-public-private/main.tf
+++ b/examples/vpc-public-private/main.tf
@@ -8,6 +8,7 @@ module "vpc" {
   project                    = "Forest"
   create_private_hosted_zone = "false"  // default = true
   create_private_subnets     = "false"  // default = true
+  create_s3_vpc_endpoint     = "false"  // default = true
 
   // example to override default availability_zones
   availability_zones = {

--- a/main.tf
+++ b/main.tf
@@ -102,10 +102,15 @@ resource "aws_route_table_association" "private_routing_table" {
   count          = "${var.create_private_subnets ? length(var.availability_zones[var.aws_region]) : 0}"
 }
 
+data "aws_vpc_endpoint_service" "s3" {
+  count = "${var.create_s3_vpc_endpoint ? 1 : 0}"
+  service = "s3"
+}
+
 resource "aws_vpc_endpoint" "s3_vpc_endpoint" {
   count = "${var.create_s3_vpc_endpoint ? 1 : 0}"
   vpc_id = "${aws_vpc.vpc.id}"
-  service_name = "${format("com.amazonaws.%s.s3", var.aws_region)}"
+  service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
   route_table_ids = ["${aws_route_table.public_routetable.id}", "${aws_route_table.private_routetable.id}"]
   policy = <<POLICY
 {

--- a/main.tf
+++ b/main.tf
@@ -112,18 +112,6 @@ resource "aws_vpc_endpoint" "s3_vpc_endpoint" {
   vpc_id = "${aws_vpc.vpc.id}"
   service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
   route_table_ids = ["${aws_route_table.public_routetable.id}", "${aws_route_table.private_routetable.id}"]
-  policy = <<POLICY
-{
-    "Statement": [
-        {
-            "Action": "*",
-            "Effect": "Allow",
-            "Resource": "*",
-            "Principal": "*"
-        }
-    ]
-}
-POLICY
 }
 
 resource "aws_eip" "nat" {

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,25 @@ resource "aws_route_table_association" "private_routing_table" {
   count          = "${var.create_private_subnets ? length(var.availability_zones[var.aws_region]) : 0}"
 }
 
+resource "aws_vpc_endpoint" "s3_vpc_endpoint" {
+  count = "${var.create_s3_vpc_endpoint ? 1 : 0}"
+  vpc_id = "${aws_vpc.vpc.id}"
+  service_name = "${format("com.amazonaws.%s.s3", var.aws_region)}"
+  route_table_ids = ["${aws_route_table.public_routetable.id}", "${aws_route_table.private_routetable.id}"]
+  policy = <<POLICY
+{
+    "Statement": [
+        {
+            "Action": "*",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Principal": "*"
+        }
+    ]
+}
+POLICY
+}
+
 resource "aws_eip" "nat" {
   count = "${var.create_private_subnets ? 1 : 0}"
   vpc   = true

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,10 @@ variable "public_subnet_map_public_ip_on_launch" {
   default = "false"
 }
 
+variable "create_s3_vpc_endpoint" {
+  default = "true"
+}
+
 variable "tags" {
   type        = "map"
   description = "Map of tags to apply on the resources"

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,7 @@ variable "public_subnet_map_public_ip_on_launch" {
 
 variable "create_s3_vpc_endpoint" {
   default = "true"
+  description = "Whether to create a VPC Endpoint for S3, so the S3 buckets can be used from within the VPC without using the NAT gateway."
 }
 
 variable "tags" {


### PR DESCRIPTION
Added a S3 VPC endpoint, so accessing S3 from within your VPC doesn't use the NAT gateway (which costs a lot of money). Which is also why it is enabled by default - so everyone who uses the module can access S3 for free.

The policy that is used is full access, which is the default behaviour when using a VPC endpoint.