### PR TITLE
Adding subnets taggings capability when creating a VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,34 +36,36 @@ module "vpc" {
 ```
 ## Inputs
 
-| Name                                        | Description                                                                                                               |    Type     |     Default     | Required |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | :---------: | :-------------: | :------: |
-| availability\_zones                         | List to specify the availability zones for which subnes will be created. By default all availability zones will be used.  |    list     |    `<list>`     |    no    |
-| aws\_region                                 | The Amazon region                                                                                                         |   string    |       n/a       |   yes    |
-| cidr\_block                                 | The CIDR block used for the VPC.                                                                                          |   string    | `"10.0.0.0/16"` |    no    |
-| create\_private\_hosted\_zone               | Indicate to create a private hosted zone.                                                                                 |    bool     |    `"true"`     |    no    |
-| create\_private\_subnets                    | Indicates to create private subnets.                                                                                      |    bool     |    `"true"`     |    no    |
-| create\_s3\_vpc\_endpoint                   | Whether to create a VPC Endpoint for S3, so the S3 buckets can be used from within the VPC without using the NAT gateway. |    bool     |    `"true"`     |    no    |
-| enable\_create\_defaults                    | Disable managing the default resources.                                                                                   |    bool     |    `"true"`     |    no    |
-| environment                                 | Environment name, will be added for resource tagging.                                                                     |   string    |       n/a       |   yes    |
-| project                                     | Project name, will be added for resource tagging.                                                                         |   string    |      `""`       |    no    |
-| public\_subnet\_map\_public\_ip\_on\_launch | Enable public ip creaton by default on EC2 instance launch.                                                               |    bool     |    `"false"`    |    no    |
-| tags                                        | Map of tags to apply on the resources                                                                                     | map(string) |     `<map>`     |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| availability\_zones | List to specify the availability zones for which subnes will be created. By default all availability zones will be used. | list | `<list>` | no |
+| aws\_region | The Amazon region | string | n/a | yes |
+| cidr\_block | The CIDR block used for the VPC. | string | `"10.0.0.0/16"` | no |
+| create\_private\_hosted\_zone | Indicate to create a private hosted zone. | bool | `"true"` | no |
+| create\_private\_subnets | Indicates to create private subnets. | bool | `"true"` | no |
+| create\_s3\_vpc\_endpoint | Whether to create a VPC Endpoint for S3, so the S3 buckets can be used from within the VPC without using the NAT gateway. | bool | `"true"` | no |
+| enable\_create\_defaults | Disable managing the default resources. | bool | `"true"` | no |
+| environment | Environment name, will be added for resource tagging. | string | n/a | yes |
+| private\_subnet\_tags | Map of tags to apply on the private subnets | map(string) | `<map>` | no |
+| project | Project name, will be added for resource tagging. | string | `""` | no |
+| public\_subnet\_map\_public\_ip\_on\_launch | Enable public ip creaton by default on EC2 instance launch. | bool | `"false"` | no |
+| public\_subnet\_tags | Map of tags to apply on the public subnets | map(string) | `<map>` | no |
+| tags | Map of tags to apply on the resources | map(string) | `<map>` | no |
 
 ## Outputs
 
-| Name                           | Description                               |
-| ------------------------------ | ----------------------------------------- |
-| availability\_zones            | List of the availability zones.           |
-| nat\_gateway\_public\_ip       | Public IP address of the NAT gateway.     |
-| private\_dns\_zone\_id         | ID of the the private DNS zone, optional. |
-| private\_domain\_name          | Private domain name, optional.            |
-| private\_subnets               | List of the private subnets.              |
-| private\_subnets\_route\_table |                                           |
-| public\_subnets                | List of the public subnets.               |
-| public\_subnets\_route\_table  |                                           |
-| vpc\_cidr                      | VPC CDIR.                                 |
-| vpc\_id                        | ID of the VPC.                            |
+| Name | Description |
+|------|-------------|
+| availability\_zones | List of the availability zones. |
+| nat\_gateway\_public\_ip | Public IP address of the NAT gateway. |
+| private\_dns\_zone\_id | ID of the the private DNS zone, optional. |
+| private\_domain\_name | Private domain name, optional. |
+| private\_subnets | List of the private subnets. |
+| private\_subnets\_route\_table |  |
+| public\_subnets | List of the public subnets. |
+| public\_subnets\_route\_table |  |
+| vpc\_cidr | VPC CDIR. |
+| vpc\_id | ID of the VPC. |
 ## Automated checks
 Currently the automated checks are limited. In CI the following checks are done for the root and each example.
 - lint: `terraform validate` and `terraform fmt`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,41 @@ module "vpc" {
 | public\_subnets\_route\_table |  |
 | vpc\_cidr | VPC CDIR. |
 | vpc\_id | ID of the VPC. |
+
+# VPC for Amazon EKS
+
+Amazon EKS (Elastic Kubernetes Service) requires that both VPCs and Subnets (public and private) are tagged specifically with certain values according to the [aws-eks-docs].
+
+Therefore, if the VPC created using this module is targeted for EKS, tag it with
+
+```terraform
+  tags = {
+    "kubernetes.io/cluster/<cluster-name>" = "my-new-tag"
+  }
+```
+
+## Subnets Tags
+
+As stated above, tagging the subnets is also mandatory for EKS Clusters. The tags for public and private subnets are as follows, respectively:
+
+### Public Subnet Tags
+
+```terraform
+  public_subnet_tags = {
+    "kubernetes.io/cluster/<cluster_name>" = "shared"
+    "kubernetes.io/role/elb"               = "1"
+  }
+```
+
+### Private Subnet Tags
+
+```terraform
+  private_subnet_tags = {
+    "kubernetes.io/cluster/<cluster_name>" = "shared"
+    "kubernetes.io/role/internal-elb"      = "1"
+  }
+```
+
 ## Automated checks
 Currently the automated checks are limited. In CI the following checks are done for the root and each example.
 - lint: `terraform validate` and `terraform fmt`
@@ -95,3 +130,4 @@ This module is part of the Philips Forest.
 Talk to the forestkeepers in the `forest`-channel on Slack.
 
 [![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
+[aws-eks-docs]: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html

--- a/examples/vpc-public-private/main.tf
+++ b/examples/vpc-public-private/main.tf
@@ -16,4 +16,13 @@ module "vpc" {
   tags = {
     my-tag = "my-new-tag"
   }
+
+  // add tags on the subnets. Mostly useful when creating EKS clusters
+  public_subnet_tags = {
+    my-public-subnet-tag = "my-public-subnet-tag-value"
+  }
+
+  private_subnet_tags = {
+    my-private-subnet-tag = "my-private-subnet-tag-value"
+  }
 }

--- a/examples/vpc-public-private/main.tf
+++ b/examples/vpc-public-private/main.tf
@@ -19,10 +19,12 @@ module "vpc" {
 
   // add tags on the subnets. Mostly useful when creating EKS clusters
   public_subnet_tags = {
-    my-public-subnet-tag = "my-public-subnet-tag-value"
+    "kubernetes.io/cluster/<cluster_name>" = "shared"
+    "kubernetes.io/role/elb"               = "1"
   }
 
   private_subnet_tags = {
-    my-private-subnet-tag = "my-private-subnet-tag-value"
+    "kubernetes.io/cluster/<cluster_name>" = "shared"
+    "kubernetes.io/role/internal-elb"      = "1"
   }
 }

--- a/examples/vpc-public/main.tf
+++ b/examples/vpc-public/main.tf
@@ -16,4 +16,9 @@ module "vpc" {
   tags = {
     my-tag = "my-new-tag"
   }
+
+  // add tags on the subnets. Mostly useful when creating EKS clusters
+  public_subnet_tags = {
+    my-public-subnet-tag = "my-public-subnet-tag-value"
+  }
 }

--- a/examples/vpc-public/main.tf
+++ b/examples/vpc-public/main.tf
@@ -19,6 +19,7 @@ module "vpc" {
 
   // add tags on the subnets. Mostly useful when creating EKS clusters
   public_subnet_tags = {
-    my-public-subnet-tag = "my-public-subnet-tag-value"
+    "kubernetes.io/cluster/<cluster_name>" = "shared"
+    "kubernetes.io/role/elb"               = "1"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_vpc" "vpc" {
   cidr_block           = cidrsubnet(var.cidr_block, 0, 0)
   enable_dns_support   = true
   enable_dns_hostnames = true
-  tags = local.tags
+  tags                 = local.tags
 }
 
 resource "aws_default_network_acl" "default" {

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,6 @@ resource "aws_vpc" "vpc" {
   cidr_block           = cidrsubnet(var.cidr_block, 0, 0)
   enable_dns_support   = true
   enable_dns_hostnames = true
-
   tags = local.tags
 }
 
@@ -129,6 +128,7 @@ resource "aws_subnet" "public_subnet" {
       "Tier" = "public"
     },
     local.tags_without_name,
+    var.public_subnet_tags
   )
 }
 
@@ -178,6 +178,7 @@ resource "aws_subnet" "private_subnet" {
       "Tier" = "private"
     },
     local.tags_without_name,
+    var.private_subnet_tags
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "public_subnet_tags" {
+  description = "Map of tags to apply on the public subnets"
+  type = map(string)
+  default = {} 
+}
+
+variable "private_subnet_tags" {
+  description = "Map of tags to apply on the private subnets"
+  type = map(string)
+  default = {}
+}
+
 variable "enable_create_defaults" {
   description = "Disable managing the default resources."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -58,14 +58,14 @@ variable "tags" {
 
 variable "public_subnet_tags" {
   description = "Map of tags to apply on the public subnets"
-  type = map(string)
-  default = {} 
+  type        = map(string)
+  default     = {}
 }
 
 variable "private_subnet_tags" {
   description = "Map of tags to apply on the private subnets"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "enable_create_defaults" {


### PR DESCRIPTION
### Motivation

When creating Kubernetes (k8s) clusters in EKS, subnets tagging is mandatory. Currently, it's not possible to create such clusters using this VPC module.

### Changes

This PR aims at enabling the tagging capability on subnets created by the VPC module

### Usage

In order to tag the subnets, simply inject values for `public_subnet_tags` and `private_subnet_tags`

```terraform
  public_subnet_tags = {
    "kubernetes.io/cluster/cluster-name" = "shared"
    "kubernetes.io/role/elb"                      = "1"
  }

  private_subnet_tags = {
    "kubernetes.io/cluster/cluster-name" = "shared"
    "kubernetes.io/role/internal-elb"             = "1"
  }
```