### PR TITLE
Set service type for S3 endpoint service to avoid error " multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,13 +191,13 @@ resource "aws_route_table_association" "private_routing_table" {
 data "aws_vpc_endpoint_service" "s3" {
   count   = var.create_s3_vpc_endpoint ? 1 : 0
   service = "s3"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc_endpoint" "s3_vpc_endpoint" {
   count        = var.create_s3_vpc_endpoint ? 1 : 0
   vpc_id       = aws_vpc.vpc.id
   service_name = element(data.aws_vpc_endpoint_service.s3.*.service_name, 0)
-
   tags = local.tags
 }
 


### PR DESCRIPTION
Users of the latest released version of this module (https://github.com/philips-software/terraform-aws-vpc.git?ref=2.1.0) like https://github.com/philips-labs/terraform-aws-github-runner are currently running into the following issue while running terraform apply:

```
Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service
```

Due to some [recent AWS API changes](https://discuss.hashicorp.com/t/notice-aws-vpc-endpoint-service-error-multiple-vpc-endpoint-services-matched/20472), the service type of S3 endpoint services has to be explicitly specified. Using the service_type parameter to explicitly ask for a `Gateway` and not a PrivateLink.