### PR TITLE
Fix S3 endpoint service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,8 +189,9 @@ resource "aws_route_table_association" "private_routing_table" {
 }
 
 data "aws_vpc_endpoint_service" "s3" {
-  count   = var.create_s3_vpc_endpoint ? 1 : 0
-  service = "s3"
+  count        = var.create_s3_vpc_endpoint ? 1 : 0
+  service      = "s3"
+  service_type = "Gateway"
 }
 
 resource "aws_vpc_endpoint" "s3_vpc_endpoint" {


### PR DESCRIPTION
Due to a change in AWS S3, the data.aws_vpc_endpoint_service.s3 was not able to identify a unique resource. This can be solved by specifying the service type.
See also the issue here: https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/445
And the change in AWS: https://aws.amazon.com/ru/blogs/aws/aws-privatelink-for-amazon-s3-now-available/